### PR TITLE
MRG: update with isolate analysis scripts, more/better taxonomy

### DIFF
--- a/bundle-results.sh
+++ b/bundle-results.sh
@@ -1,0 +1,4 @@
+#! /bin/bash
+zip -r sinks-results-today.zip sink_metag/JRH_{?,??}.*{out,csv} \
+    isolates.x.metagenomes.manysearch.csv isolates.x.metagenomes.summary.csv \
+    sink_metag/JRH_combined.kreport.csv

--- a/isolate-manysearch.sh
+++ b/isolate-manysearch.sh
@@ -1,0 +1,9 @@
+#! /bin/bash
+
+# make list of isolates
+for i in *.sig.gz; do echo $(pwd)/$i; done > ../list.isolate-assemblies.txt
+
+# run manysearch
+sourmash scripts manysearch -k 21 list.isolate-assemblies.txt \
+    sink_metag/JRH_all.k21.sigs.zip -c 4  -t 0 \
+    -o isolates.x.metagenomes.manysearch.csv

--- a/isolate-manysearch.sh
+++ b/isolate-manysearch.sh
@@ -7,3 +7,6 @@ for i in *.sig.gz; do echo $(pwd)/$i; done > ../list.isolate-assemblies.txt
 sourmash scripts manysearch -k 21 list.isolate-assemblies.txt \
     sink_metag/JRH_all.k21.sigs.zip -c 4  -t 0 \
     -o isolates.x.metagenomes.manysearch.csv
+
+# summarize
+./summarize-manysearch.py isolates.x.metagenomes.manysearch.csv -o isolates.x.metagenomes.summary.csv

--- a/sink_metag/combine-kreports.py
+++ b/sink_metag/combine-kreports.py
@@ -1,4 +1,7 @@
 #! /usr/bin/env python
+"""
+Combine multiple sourmash tax metagenome -F kreport files.
+"""
 import sys
 import csv
 import argparse

--- a/sink_metag/combine-kreports.py
+++ b/sink_metag/combine-kreports.py
@@ -17,7 +17,7 @@ def main():
         df = pd.read_csv(filename, sep='\t',
                          names=['percent', 'bp', 'a', 'rank', 'empty', 'name'])
 
-        df = df[df['rank'] == 'S']
+        df = df[df['rank'].isin(['S', 'U'])]
         df = df[['percent', 'name']]
         df = df.rename(columns={'percent': name})
         dfs.append(df)

--- a/summarize-manysearch.py
+++ b/summarize-manysearch.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 """
-Combine multiple sourmash tax metagenome -F kreport files.
+Combine multiple sourmash containment reports for isolates x many metagenomes.
 """
 import sys
 import csv

--- a/summarize-manysearch.py
+++ b/summarize-manysearch.py
@@ -1,0 +1,71 @@
+#! /usr/bin/env python
+"""
+Combine multiple sourmash tax metagenome -F kreport files.
+"""
+import sys
+import csv
+import argparse
+import pandas as pd
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument('manysearch_csv')
+    p.add_argument('-o', '--output', required=True)
+    args = p.parse_args()
+
+    df = pd.read_csv(args.manysearch_csv)
+    print(df.head())
+
+    samples = list(sorted(set(df['match_name'])))
+    print(f'samples: {samples}')
+
+    queries = list(sorted(set(df['query_name'])))
+
+    sample_dfs = {}
+    for sample in samples:
+        sample_df = df[df['match_name'] == sample]
+        sample_df = sample_df[['query_name', 'containment']]
+        sample_dfs[sample] = sample_df
+
+    # go through and merge, retaining the column named `containment`;
+    # rename the containment column to cont_{sample}.
+
+    # do the first sample:
+    sample = samples.pop(0)
+    combined_df = sample_dfs[sample]
+    combined_df.rename(columns={'containment': sample}, inplace=True)
+
+    # and then... the rest!
+    while samples:
+        sample = samples.pop(0)
+        sample_df = sample_dfs[sample]
+        sample_df = sample_df[['query_name', 'containment']]
+        sample_df.rename(columns={'containment': sample},
+                         inplace=True)
+        combined_df = combined_df.merge(sample_df, on='query_name',
+                                        how='outer')
+
+    combined_df.rename(columns={'query_name': 'genome'}, inplace=True)
+
+    print(combined_df.head())
+
+    #join_df.sort_values(by='max', inplace=True, ascending=False)
+
+    # get the list of data columns
+    cols = combined_df.columns.tolist()
+    cols.remove('genome')
+    data_cols = list(cols)
+
+    # add in a max column
+    combined_df['max'] = combined_df[data_cols].max(axis=1)
+
+    # sort!
+    combined_df.sort_values(by='max', inplace=True, ascending=False)
+
+    # save!
+    combined_df.to_csv(args.output)
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
* include unassigned taxonomy entries so things add up to 100%;
* add a `manysearch` containment analysis that provides information about isolate containment across metagenomes